### PR TITLE
Increase to avoid libarclite error

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -1,5 +1,5 @@
 source 'https://github.com/CocoaPods/Specs.git'
-platform :ios, '8.0'
+platform :ios, '12.0'
 
 target "Replete" do
 end

--- a/Replete.xcodeproj/project.pbxproj
+++ b/Replete.xcodeproj/project.pbxproj
@@ -520,7 +520,7 @@
 				DEVELOPMENT_TEAM = FMH366978P;
 				HEADER_SEARCH_PATHS = "$(PROJECT_DIR)/Replete/curl/include";
 				INFOPLIST_FILE = Replete/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
@@ -548,7 +548,7 @@
 				DEVELOPMENT_TEAM = FMH366978P;
 				HEADER_SEARCH_PATHS = "$(PROJECT_DIR)/Replete/curl/include";
 				INFOPLIST_FILE = Replete/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",


### PR DESCRIPTION
Showing Recent Errors Only
SDK does not contain 'libarclite' at the path '/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/arc/libarclite_iphoneos.a'; try increasing the minimum deployment target